### PR TITLE
Add annex card to DAIU request flow

### DIFF
--- a/public/css/daiu/solicitud.css
+++ b/public/css/daiu/solicitud.css
@@ -85,6 +85,21 @@ input[type="checkbox"] {
 }
 
 
+.anexos-check {
+    gap: 10px;
+}
+
+.anexos-check i {
+    margin-left: 10px;
+    font-size: 1.1rem;
+}
+
+.anexos-check .form-check-label {
+    margin-left: 10px;
+    line-height: 1.2;
+}
+
+
 #map {
     width: 100%; /* Ocupa todo el ancho disponible */
     height: 500px; /* Ajusta la altura según lo que necesites */

--- a/public/js/daiu/anexos_memoria.js
+++ b/public/js/daiu/anexos_memoria.js
@@ -1,0 +1,45 @@
+$(document).ready(function() {
+    $("#btn_regresar_card6").on("click", function(e) {
+        e.preventDefault();
+        mostrarCard("card_6", "card_5");
+    });
+
+    $("#form_6").on("submit", function(e) {
+        e.preventDefault();
+
+        const anexosSeleccionados =
+            $("input[name='anexos[]']:checked").map(function() {
+                return $(this)
+                    .closest(".anexos-check")
+                    .find("label")
+                    .text()
+                    .trim();
+            }).get();
+
+        const resumen = [
+            anexosSeleccionados.length
+                ? `Anexos seleccionados: ${anexosSeleccionados.join(", ")}`
+                : "Sin anexos seleccionados",
+            $("#memoria_descriptiva").val().trim()
+                ? "Memoria descriptiva capturada"
+                : "Sin memoria descriptiva",
+            $("#numero_color").val().trim() ||
+            $("#tipo_letra").val().trim() ||
+            $("#dim_altura").val().trim() ||
+            $("#dim_ancho").val().trim() ||
+            $("#dim_fondo").val().trim()
+                ? "Dimensiones registradas"
+                : "Sin dimensiones de fachada"
+        ].join("\n");
+
+        Swal.fire({
+            icon: "success",
+            title: "Información guardada",
+            text: resumen,
+            confirmButtonText: "Aceptar",
+            customClass: {
+                confirmButton: "ab-btn b-primary-color"
+            }
+        });
+    });
+});

--- a/public/js/daiu/croquis_mapa.js
+++ b/public/js/daiu/croquis_mapa.js
@@ -257,6 +257,16 @@ $(document).ready(function() {
         }
     });
 
+    $("#btn_regresar_card5").on("click", function(e) {
+        e.preventDefault();
+        mostrarCard("card_5", "card_4");
+    });
+
+    $("#btn_inserta_5").on("click", function(e) {
+        e.preventDefault();
+        mostrarCard("card_5", "card_6");
+    });
+
     function loadArcGISScript() {
         return new Promise(function(resolve, reject) {
             const script = document.createElement("script");

--- a/resources/views/daiu/partials/anexos_memoria.blade.php
+++ b/resources/views/daiu/partials/anexos_memoria.blade.php
@@ -1,0 +1,111 @@
+<div class="row">
+    <div class="col mt-4" id="top_6">
+        <div class="card shadow-sm card_6 rounded border-none">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <small>Anexos y memoria descriptiva</small>
+            </div>
+            <div class="card-body" style="display: none;">
+                <form id="form_6">
+                    {{-- Anexos --}}
+                    <div class="mb-4">
+                        <label class="d-block mb-2"><strong>Anexos requeridos</strong></label>
+                        <div class="row">
+                            @foreach ([
+                                'levantamiento_fotografico' => [
+                                    'label' => 'Levantamiento fotográfico',
+                                    'icon' => 'fa-camera'
+                                ],
+                                'cedula_licencia' => [
+                                    'label' => 'Cédula de licencia municipal para giro o anuncio (copia)',
+                                    'icon' => 'fa-id-card'
+                                ],
+                                'memoria_acciones' => [
+                                    'label' => 'Memoria descriptiva de las acciones a realizar',
+                                    'icon' => 'fa-file-lines'
+                                ],
+                                'plano_proyecto' => [
+                                    'label' => 'Plano a escala del proyecto arquitectónico (escala, digital o formato DWG versión 2018)',
+                                    'icon' => 'fa-drafting-compass'
+                                ],
+                                'fotografias_inmueble' => [
+                                    'label' => 'Fotografías digitales del inmueble y anexos de intervención',
+                                    'icon' => 'fa-images'
+                                ],
+                                'cotizacion_proveedor' => [
+                                    'label' => 'Cotización o presupuesto del proveedor (justificación)',
+                                    'icon' => 'fa-file-invoice-dollar'
+                                ],
+                            ] as $id => $item)
+                                <div class="col-md-6 col-lg-4 mb-3">
+                                    <div class="form-check anexos-check d-flex align-items-center">
+                                        <input type="checkbox" class="form-check-input" id="{{ $id }}" name="anexos[]"
+                                            value="{{ $id }}">
+                                        <i class="fas {{ $item['icon'] }} text-muted"></i>
+                                        <label class="form-check-label" for="{{ $id }}">{{ $item['label'] }}</label>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    {{-- Memoria descriptiva --}}
+                    <div class="form-group">
+                        <label for="memoria_descriptiva"><strong>Memoria descriptiva</strong></label>
+                        <textarea class="form-control" id="memoria_descriptiva" name="memoria_descriptiva" rows="5"
+                            placeholder="Describe a detalle las acciones que se realizarán en el inmueble"></textarea>
+                        <small class="form-text text-muted">Puedes detallar materiales, acabados y cualquier otra
+                            consideración relevante.</small>
+                    </div>
+
+                    {{-- Dimensiones de la fachada --}}
+                    <div class="mt-4">
+                        <label class="d-block mb-3"><strong>Dimensiones de la fachada (ejemplo)</strong></label>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="numero_color">No. color</label>
+                                <input type="text" class="form-control" id="numero_color" name="numero_color"
+                                    placeholder="Ej. Verde 22-45">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="tipo_letra">Letra individual</label>
+                                <input type="text" class="form-control" id="tipo_letra" name="tipo_letra"
+                                    placeholder="Ej. Acero inoxidable">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_altura">Altura (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_altura"
+                                    name="dim_altura" placeholder="Ej. 2.50">
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_ancho">Ancho (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_ancho"
+                                    name="dim_ancho" placeholder="Ej. 5.20">
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_fondo">Fondo (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_fondo"
+                                    name="dim_fondo" placeholder="Ej. 0.40">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="dim_observaciones">Observaciones</label>
+                            <textarea class="form-control" id="dim_observaciones" name="dim_observaciones" rows="3"
+                                placeholder="Incluye referencias de materiales, iluminación u otros datos que faciliten la revisión."></textarea>
+                        </div>
+                    </div>
+
+                    <div class="text-right mt-4">
+                        <button type="button" id="btn_regresar_card6" class="ab-btn btn-primary-color btn-style me-2">
+                            Regresar al croquis
+                        </button>
+                        <button type="submit" class="ab-btn b-primary-color btn-style" id="btn_finalizar_solicitud">
+                            Guardar información
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/daiu/partials/croquis_mapa.blade.php
+++ b/resources/views/daiu/partials/croquis_mapa.blade.php
@@ -16,8 +16,20 @@
                             <button type="button" id="btn_guardar_mapa" class="ab-btn b-primary-color btn-style">
                                 Guardar Croquis
                             </button>
-                            <button type="button" id="btn_limpiar_mapa" class="ab-btn b-secondary-color btn-style ml-2">
+                            <button type="button" id="btn_limpiar_mapa"
+                                class="ab-btn b-secondary-color btn-style ml-2">
                                 Limpiar Mapa
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="row mt-4">
+                        <div class="col-md-12 text-right">
+                            <button type="button" id="btn_regresar_card5" class="ab-btn btn-primary-color btn-style me-2">
+                                Regresar a información del inmueble
+                            </button>
+                            <button type="button" id="btn_inserta_5" class="ab-btn b-primary-color btn-style">
+                                Continuar con anexos
                             </button>
                         </div>
                     </div>

--- a/resources/views/daiu/solicitud.blade.php
+++ b/resources/views/daiu/solicitud.blade.php
@@ -20,6 +20,7 @@
     @include('daiu.partials.selector_adecuaciones', ['id_solicitud' => $id_solicitud])
     @include('daiu.partials.inmueble_informacion', ['id_solicitud' => $id_solicitud])
     @include('daiu.partials.croquis_mapa', ['id_solicitud' => $id_solicitud])
+    @include('daiu.partials.anexos_memoria', ['id_solicitud' => $id_solicitud])
 
 @endsection
 
@@ -49,4 +50,5 @@
     <script src="{{ asset('js/daiu/inmueble_informacion.js') }}"></script>
     <script src="https://js.arcgis.com/4.25/"></script>
     <script src="{{ asset('js/daiu/croquis_mapa.js') }}"></script>
+    <script src="{{ asset('js/daiu/anexos_memoria.js') }}"></script>
 @endsection


### PR DESCRIPTION
## Summary
- add a new "Anexos y memoria descriptiva" card to the DAIU solicitud view with annex checklists, descriptive text fields, and facade dimensions inputs
- extend the croquis card with navigation controls and supporting scripts/styles to reach the new step and summarise the captured data

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4686f5a88832e97d495aac37e0003