### PR TITLE
Add documentación step and adjust croquis navigation

### DIFF
--- a/public/css/daiu/solicitud.css
+++ b/public/css/daiu/solicitud.css
@@ -9,6 +9,73 @@
     background-color: #154249 !important;
     color: white !important;
 }
+.step-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.step-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background-color: #1e636d;
+    color: #fff;
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.step-title {
+    font-weight: 600;
+    color: #1e636d;
+    font-size: 0.95rem;
+}
+
+.step-flow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 18px;
+}
+
+.step-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.step-circle {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 2px solid #1e636d;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: #1e636d;
+    background-color: #fff;
+}
+
+.step-label {
+    font-size: 0.75rem;
+    color: #6c757d;
+    text-align: center;
+    max-width: 100px;
+    line-height: 1.1;
+}
+
+.step-line {
+    flex: 0 0 50px;
+    height: 2px;
+    background-color: #d1d1d1;
+}
+
 .categoria-card {
     cursor: pointer;
     text-align: center;
@@ -82,6 +149,21 @@ input[type="checkbox"] {
 
 .iconos-lista-min{
     gap: 6px;
+}
+
+
+.anexos-check {
+    gap: 10px;
+}
+
+.anexos-check i {
+    margin-left: 10px;
+    font-size: 1.1rem;
+}
+
+.anexos-check .form-check-label {
+    margin-left: 10px;
+    line-height: 1.2;
 }
 
 

--- a/public/js/daiu/anexos_memoria.js
+++ b/public/js/daiu/anexos_memoria.js
@@ -1,0 +1,47 @@
+$(document).ready(function() {
+    $("#btn_regresar_card6").on("click", function(e) {
+        e.preventDefault();
+        mostrarCard("card_6", "card_5");
+    });
+
+    $("#form_6").on("submit", function(e) {
+        e.preventDefault();
+
+        const anexosSeleccionados =
+            $("input[name='anexos[]']:checked").map(function() {
+                return $(this)
+                    .closest(".anexos-check")
+                    .find("label")
+                    .text()
+                    .trim();
+            }).get();
+
+        const resumen = [
+            anexosSeleccionados.length
+                ? `Anexos seleccionados: ${anexosSeleccionados.join(", ")}`
+                : "Sin anexos seleccionados",
+            $("#memoria_descriptiva").val().trim()
+                ? "Memoria descriptiva capturada"
+                : "Sin memoria descriptiva",
+            $("#numero_color").val().trim() ||
+            $("#tipo_letra").val().trim() ||
+            $("#dim_altura").val().trim() ||
+            $("#dim_ancho").val().trim() ||
+            $("#dim_fondo").val().trim()
+                ? "Dimensiones registradas"
+                : "Sin dimensiones de fachada"
+        ].join("\n");
+
+        Swal.fire({
+            icon: "success",
+            title: "Información guardada",
+            text: resumen,
+            confirmButtonText: "Aceptar",
+            customClass: {
+                confirmButton: "ab-btn b-primary-color"
+            }
+        }).then(() => {
+            mostrarCard("card_6", "card_7");
+        });
+    });
+});

--- a/public/js/daiu/consulta_predial.js
+++ b/public/js/daiu/consulta_predial.js
@@ -37,9 +37,6 @@ function consultarPredial(cuenta) {
                 });
 
                 mostrarCard("card_1", "card_2");
-
-                $(".editable").prop("disabled", true);
-                $("#btn_editar_campos").show();
             } else {
                 iziToast.warning({
                     title: "Ups",
@@ -117,8 +114,5 @@ $(document).ready(function() {
     // Manejo del botón "Continuar sin consultar"
     $("#continuar_sin_consulta").click(function() {
         mostrarCard("card_1", "card_2");
-        $(".editable").prop("disabled", false);
-        $("#btn_inserta_2").prop("disabled", false);
-        $("#btn_editar_campos").hide();
     });
 });

--- a/public/js/daiu/croquis_mapa.js
+++ b/public/js/daiu/croquis_mapa.js
@@ -82,7 +82,7 @@ function initMap() {
         }
 
         function setupUIButtons() {
-            window.placeMarker = function(coords) {
+            window.placeMarker = function(coords, options = {}) {
                 if (!coords) return;
 
                 if (marker) {
@@ -111,14 +111,16 @@ function initMap() {
                               latitude: coords.latitude ?? coords.y
                           });
 
+                const zoomLevel = options.zoom ?? 16;
+
                 view.goTo({
                     target: point,
-                    zoom: 16
+                    zoom: zoomLevel
                 }).catch(function(error) {
                     if (error.name !== "view:goto-interrupted") {
                         console.warn("Error real en animación goTo:", error);
                         view.center = [point.longitude, point.latitude];
-                        view.zoom = 12;
+                        view.zoom = zoomLevel;
                     }
                 });
 
@@ -130,15 +132,13 @@ function initMap() {
             };
 
             window.clearMap = function() {
-                if (marker) {
-                    view.graphics.remove(marker);
-                    marker = null;
-                }
-                document.getElementById("coordinates-display").textContent = "";
-                view.goTo({
-                    center: DEFAULT_CENTER,
-                    zoom: DEFAULT_ZOOM
+                const defaultPoint = new Point({
+                    longitude: DEFAULT_CENTER[0],
+                    latitude: DEFAULT_CENTER[1]
                 });
+
+                placeMarker(defaultPoint, { zoom: DEFAULT_ZOOM });
+                updateCoordinatesDisplay(defaultPoint);
             };
         }
 
@@ -172,16 +172,8 @@ function initMap() {
                           latitude: geometry.latitude ?? geometry.y
                       });
 
-            placeMarker(point);
+            placeMarker(point, { zoom: 18 });
             updateCoordinatesDisplay(point);
-            view.goTo({
-                target: point,
-                zoom: 10
-            }).catch(function(error) {
-                console.warn("Error en animación goTo:", error);
-                view.center = [point.longitude, point.latitude];
-                view.zoom = 20;
-            });
         }
 
         function updateCoordinatesDisplay(coords) {
@@ -234,16 +226,35 @@ $(document).ready(function() {
     $("#btn_guardar_mapa").click(function(e) {
         e.preventDefault();
         const coords = window.getMarkerCoords();
-        if (coords) {
-            const lat = coords.latitude?.toFixed(6) || coords.y?.toFixed(6);
-            const lng = coords.longitude?.toFixed(6) || coords.x?.toFixed(6);
 
-            alert(`Ubicación guardada:\nLatitud: ${lat}\nLongitud: ${lng}`);
-        } else {
-            alert(
-                "Por favor, selecciona una ubicación en el mapa haciendo click o usando la búsqueda."
-            );
+        if (!coords) {
+            Swal.fire({
+                icon: "warning",
+                title: "Selecciona una ubicación",
+                text:
+                    "Por favor, coloca un punto en el mapa haciendo clic o utilizando la búsqueda.",
+                confirmButtonColor: "#1E636D"
+            });
+            return;
         }
+
+        const lat = coords.latitude?.toFixed(6) || coords.y?.toFixed(6);
+        const lng = coords.longitude?.toFixed(6) || coords.x?.toFixed(6);
+
+        Swal.fire({
+            icon: "success",
+            title: "Croquis guardado",
+            text: `Latitud: ${lat}, Longitud: ${lng}`,
+            confirmButtonText: "Continuar",
+            confirmButtonColor: "#1E636D"
+        }).then(() => {
+            mostrarCard("card_5", "card_6");
+        });
+    });
+
+    $("#btn_regresar_card5").click(function(e) {
+        e.preventDefault();
+        mostrarCard("card_5", "card_4");
     });
 
     $("#btn_limpiar_mapa").click(function(e) {

--- a/public/js/daiu/datos_solicitante.js
+++ b/public/js/daiu/datos_solicitante.js
@@ -1,13 +1,4 @@
 $(document).ready(function() {
-    $("#btn_editar_campos").click(function() {
-        $(".editable").prop("disabled", false);
-        $("#btn_inserta_2").prop("disabled", false);
-        iziToast.info({
-            message: "Ahora puedes editar los campos.",
-            position: "topRight"
-        });
-    });
-
     $("#form_2").submit(function(e) {
         e.preventDefault();
 
@@ -44,7 +35,5 @@ $(document).ready(function() {
 
     $("#btn_regresar").click(function() {
         mostrarCard("card_2", "card_1");
-        $(".editable").prop("disabled", true);
-        $("#btn_editar_campos").hide();
     });
 });

--- a/public/js/daiu/documentacion.js
+++ b/public/js/daiu/documentacion.js
@@ -1,0 +1,33 @@
+$(document).ready(function() {
+    $("#btn_regresar_card7").on("click", function(e) {
+        e.preventDefault();
+        mostrarCard("card_7", "card_6");
+    });
+
+    $("#form_7").on("submit", function(e) {
+        e.preventDefault();
+
+        const archivos = $(this)
+            .find("input[type='file']")
+            .map(function() {
+                const files = $(this)[0].files;
+                return files && files.length ? files[0].name : null;
+            })
+            .get()
+            .filter(Boolean);
+
+        const mensaje = archivos.length
+            ? `Archivos seleccionados: ${archivos.join(", ")}`
+            : "Aún no se han seleccionado archivos.";
+
+        Swal.fire({
+            icon: "info",
+            title: "Documentación en maqueta",
+            text: `${mensaje} La carga final se habilitará próximamente.`,
+            confirmButtonText: "Entendido",
+            customClass: {
+                confirmButton: "ab-btn b-primary-color"
+            }
+        });
+    });
+});

--- a/public/js/daiu/solicitud.js
+++ b/public/js/daiu/solicitud.js
@@ -88,9 +88,6 @@ $(document).ready(function() {
                     });
 
                     mostrarCard("card_1", "card_2");
-
-                    $(".editable").prop("disabled", true);
-                    $("#btn_editar_campos").show();
                 } else {
                     iziToast.warning({
                         title: "Ups",
@@ -114,18 +111,6 @@ $(document).ready(function() {
     }
 
     // ==== Eventos principales ====
-
-    // Deshabilitar campos inicialmente
-    $(".editable").prop("disabled", true);
-
-    $("#btn_editar_campos").click(function() {
-        $(".editable").prop("disabled", false);
-        $("#btn_inserta_2").prop("disabled", false);
-        iziToast.info({
-            message: "Ahora puedes editar los campos.",
-            position: "topRight"
-        });
-    });
 
     $("#form_1").submit(function(e) {
         e.preventDefault();
@@ -162,15 +147,10 @@ $(document).ready(function() {
 
     $("#continuar_sin_consulta").click(function() {
         mostrarCard("card_1", "card_2");
-        $(".editable").prop("disabled", false);
-        $("#btn_inserta_2").prop("disabled", false);
-        $("#btn_editar_campos").hide();
     });
 
     $("#btn_regresar").click(function() {
         mostrarCard("card_2", "card_1");
-        $(".editable").prop("disabled", true);
-        $("#btn_editar_campos").hide();
     });
 
     $("#form_2").submit(function(e) {

--- a/resources/views/daiu/partials/anexos_memoria.blade.php
+++ b/resources/views/daiu/partials/anexos_memoria.blade.php
@@ -1,0 +1,114 @@
+<div class="row">
+    <div class="col mt-4" id="top_6">
+        <div class="card shadow-sm card_6 rounded border-none">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div class="step-header">
+                    <span class="step-badge">6</span>
+                    <small class="step-title">Anexos</small>
+                </div>
+            </div>
+            <div class="card-body" style="display: none;">
+                <form id="form_6">
+                    {{-- Anexos --}}
+                    <div class="mb-4">
+                        <label class="d-block mb-2"><strong>Anexos requeridos</strong></label>
+                        <div class="row">
+                            @foreach ([
+                                'levantamiento_fotografico' => [
+                                    'label' => 'Levantamiento fotográfico',
+                                    'icon' => 'fa-camera'
+                                ],
+                                'cedula_licencia' => [
+                                    'label' => 'Cédula de licencia municipal para giro o anuncio (copia)',
+                                    'icon' => 'fa-id-card'
+                                ],
+                                'memoria_acciones' => [
+                                    'label' => 'Memoria descriptiva de las acciones a realizar',
+                                    'icon' => 'fa-file-lines'
+                                ],
+                                'plano_proyecto' => [
+                                    'label' => 'Plano a escala del proyecto arquitectónico (escala, digital o formato DWG versión 2018)',
+                                    'icon' => 'fa-drafting-compass'
+                                ],
+                                'fotografias_inmueble' => [
+                                    'label' => 'Fotografías digitales del inmueble y anexos de intervención',
+                                    'icon' => 'fa-images'
+                                ],
+                                'cotizacion_proveedor' => [
+                                    'label' => 'Cotización o presupuesto del proveedor (justificación)',
+                                    'icon' => 'fa-file-invoice-dollar'
+                                ],
+                            ] as $id => $item)
+                                <div class="col-md-6 col-lg-4 mb-3">
+                                    <div class="form-check anexos-check d-flex align-items-center">
+                                        <input type="checkbox" class="form-check-input" id="{{ $id }}" name="anexos[]"
+                                            value="{{ $id }}">
+                                        <i class="fas {{ $item['icon'] }} text-muted"></i>
+                                        <label class="form-check-label" for="{{ $id }}">{{ $item['label'] }}</label>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    {{-- Memoria descriptiva --}}
+                    <div class="form-group">
+                        <label for="memoria_descriptiva"><strong>Memoria descriptiva</strong></label>
+                        <textarea class="form-control" id="memoria_descriptiva" name="memoria_descriptiva" rows="5"
+                            placeholder="Describe a detalle las acciones que se realizarán en el inmueble"></textarea>
+                        <small class="form-text text-muted">Puedes detallar materiales, acabados y cualquier otra
+                            consideración relevante.</small>
+                    </div>
+
+                    {{-- Dimensiones de la fachada --}}
+                    <div class="mt-4">
+                        <label class="d-block mb-3"><strong>Dimensiones de la fachada (ejemplo)</strong></label>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="numero_color">No. color</label>
+                                <input type="text" class="form-control" id="numero_color" name="numero_color"
+                                    placeholder="Ej. Verde 22-45">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="tipo_letra">Letra individual</label>
+                                <input type="text" class="form-control" id="tipo_letra" name="tipo_letra"
+                                    placeholder="Ej. Acero inoxidable">
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_altura">Altura (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_altura"
+                                    name="dim_altura" placeholder="Ej. 2.50">
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_ancho">Ancho (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_ancho"
+                                    name="dim_ancho" placeholder="Ej. 5.20">
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="dim_fondo">Fondo (m)</label>
+                                <input type="number" min="0" step="0.01" class="form-control" id="dim_fondo"
+                                    name="dim_fondo" placeholder="Ej. 0.40">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="dim_observaciones">Observaciones</label>
+                            <textarea class="form-control" id="dim_observaciones" name="dim_observaciones" rows="3"
+                                placeholder="Incluye referencias de materiales, iluminación u otros datos que faciliten la revisión."></textarea>
+                        </div>
+                    </div>
+
+                    <div class="text-right mt-4">
+                        <button type="button" id="btn_regresar_card6" class="ab-btn btn-primary-color btn-style me-2">
+                            Regresar al croquis
+                        </button>
+                        <button type="submit" class="ab-btn b-primary-color btn-style" id="btn_finalizar_solicitud">
+                            Guardar información
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/daiu/partials/consulta_predial.blade.php
+++ b/resources/views/daiu/partials/consulta_predial.blade.php
@@ -2,7 +2,10 @@
     <div class="col mt-4" id="top_1">
         <div class="card  shadow-sm card_1 rounded border-none">
             <div class="card-header">
-                <small>Consulta Cuenta Predial</small>
+                <div class="step-header">
+                    <span class="step-badge">1</span>
+                    <small class="step-title">Consulta</small>
+                </div>
             </div>
             <div class="card-body">
                 <form id="form_1" method="POST" action="{{ route('consulta_predial') }}" data-parsley-validate="">

--- a/resources/views/daiu/partials/croquis_mapa.blade.php
+++ b/resources/views/daiu/partials/croquis_mapa.blade.php
@@ -2,7 +2,10 @@
     <div class="col mt-4" id="top_5">
         <div class="card shadow-sm card_5 rounded border-none">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <small>Croquis del Mapa</small>
+                <div class="step-header">
+                    <span class="step-badge">5</span>
+                    <small class="step-title">Croquis</small>
+                </div>
             </div>
             <div class="card-body" style="display: none;">
                 <form id="form_5">
@@ -12,12 +15,23 @@
 
                     {{-- Botón para guardar la ubicación --}}
                     <div class="row mt-4">
-                        <div class="col-md-12 text-right">
-                            <button type="button" id="btn_guardar_mapa" class="ab-btn b-primary-color btn-style">
-                                Guardar Croquis
+                        <div class="col-md-12 d-flex justify-content-center flex-wrap gap-3">
+                            <button type="button" id="btn_limpiar_mapa"
+                                class="ab-btn b-secondary-color btn-style">
+                                Limpiar mapa y reiniciar el punto original
                             </button>
-                            <button type="button" id="btn_limpiar_mapa" class="ab-btn b-secondary-color btn-style ml-2">
-                                Limpiar Mapa
+                        </div>
+                    </div>
+
+                    <div class="row mt-3">
+                        <div class="col-md-12 d-flex justify-content-center flex-wrap gap-3">
+                            <button type="button" id="btn_regresar_card5"
+                                class="ab-btn btn-primary-color btn-style">
+                                Regresar
+                            </button>
+                            <button type="button" id="btn_guardar_mapa"
+                                class="ab-btn b-primary-color btn-style">
+                                Continuar con anexos
                             </button>
                         </div>
                     </div>

--- a/resources/views/daiu/partials/datos_solicitante.blade.php
+++ b/resources/views/daiu/partials/datos_solicitante.blade.php
@@ -2,7 +2,10 @@
     <div class="col mt-4" id="top_2">
         <div class="card shadow-sm card_2 rounded border-none">
             <div class="card-header">
-                <small>Datos para la Verificación</small>
+                <div class="step-header">
+                    <span class="step-badge">2</span>
+                    <small class="step-title">Verificación</small>
+                </div>
             </div>
             <div class="card-body" style="display: none;">
                 <form id="form_2" data-parsley-validate="">
@@ -81,14 +84,13 @@
                         <div class="col mt-2">
                             <label for="telefono"><small>Teléfono</small></label>
                             <input name="telefono" id="telefono"
-                                class="ab-form background-color rounded border capitalize editable" type="text"
+                                class="ab-form background-color rounded border editable" type="text"
                                 required>
                         </div>
                         <div class="col mt-2">
                             <label for="correo"><small>Correo Electrónico</small></label>
                             <input name="correo" id="correo"
-                                class="ab-form background-color rounded border capitalize editable" type="email"
-                                required>
+                                class="ab-form background-color rounded border editable" type="email" required>
                         </div>
                     </div>
                     <div class="row mt-4">
@@ -97,19 +99,13 @@
                             <input name="id_captura" id="id_captura_frm4" type="hidden"
                                 value="{{ isset($id_captura) ? $id_captura : '' }}">
 
-                            <!-- Botón para habilitar la edición -->
-                            <button type="button" id="btn_editar_campos" class="ab-btn btn-warning-color btn-style">
-                                Editar campos
-                            </button>
-
                             <!-- Botón para regresar -->
                             <button type="button" id="btn_regresar" class="ab-btn btn-primary-color mt-4 btn-style">
                                 Regresar a la consulta
                             </button>
 
                             <!-- Botón para continuar -->
-                            <button type="submit" class="ab-btn b-primary-color btn-style" id="btn_inserta_2"
-                                disabled>
+                            <button type="submit" class="ab-btn b-primary-color btn-style" id="btn_inserta_2">
                                 Continuar
                             </button>
                         </div>

--- a/resources/views/daiu/partials/documentacion.blade.php
+++ b/resources/views/daiu/partials/documentacion.blade.php
@@ -1,0 +1,40 @@
+<div class="row">
+    <div class="col mt-4" id="top_7">
+        <div class="card shadow-sm card_7 rounded border-none">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div class="step-header">
+                    <span class="step-badge">7</span>
+                    <small class="step-title">Documentación</small>
+                </div>
+            </div>
+            <div class="card-body" style="display: none;">
+                <form id="form_7">
+                    <p class="text-muted">Carga de documentos de prueba. En próximas iteraciones se añadirá la funcionalidad de almacenamiento.</p>
+                    <div class="row">
+                        @foreach ([
+                            'Identificación oficial',
+                            'Comprobante de domicilio',
+                            'Plano arquitectónico firmado',
+                            'Memoria descriptiva firmada'
+                        ] as $index => $label)
+                            <div class="col-md-6 mb-3">
+                                <label for="documento_{{ $index }}">{{ $label }}</label>
+                                <input type="file" class="form-control" id="documento_{{ $index }}" name="documento_{{ $index }}">
+                                <small class="form-text text-muted">Sólo maqueta visual, sin carga real.</small>
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <div class="d-flex justify-content-end flex-wrap gap-3 mt-4">
+                        <button type="button" id="btn_regresar_card7" class="ab-btn btn-primary-color btn-style">
+                            Regresar a anexos
+                        </button>
+                        <button type="submit" id="btn_finalizar_tramite" class="ab-btn b-primary-color btn-style">
+                            Guardar documentación
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/daiu/partials/etapas.blade.php
+++ b/resources/views/daiu/partials/etapas.blade.php
@@ -1,80 +1,27 @@
+@php
+    $pasos = [
+        ['numero' => 1, 'titulo' => 'Consulta'],
+        ['numero' => 2, 'titulo' => 'Verificación'],
+        ['numero' => 3, 'titulo' => 'Adecuaciones'],
+        ['numero' => 4, 'titulo' => 'Inmueble'],
+        ['numero' => 5, 'titulo' => 'Croquis'],
+        ['numero' => 6, 'titulo' => 'Anexos'],
+        ['numero' => 7, 'titulo' => 'Documentación'],
+    ];
+@endphp
+
 <div class="row mt-5 etapas_info">
     <div class="col">
-        <div class="etapas d-flex justify-content-center align-items-center">
-
-            {{-- Etapa 1 --}}
-            <div style="width: 60px;" class="d-flex flex-column justify-content-center align-items-center">
-                <div class="etapa border {{ $id_etapa == 172 ? 'process' : 'active' }} d-flex justify-content-center align-items-center">
-                    @if ($id_etapa != 172)
-                        <div class="success d-flex justify-content-center align-items-center">
-                            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-check2 bold text-white"
-                                 fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                <path fill-rule="evenodd"
-                                      d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
-                            </svg>
-                        </div>
-                    @endif
-                    <small class="font f-15 bold {{ $id_etapa != 172 ? '' : 'text-muted' }}">1</small>
+        <div class="step-flow">
+            @foreach ($pasos as $paso)
+                <div class="step-item">
+                    <div class="step-circle">{{ $paso['numero'] }}</div>
+                    <div class="step-label">{{ $paso['titulo'] }}</div>
                 </div>
-                <small class="mt-1 mb-1 font c-carbon f-10">Solicitud</small>
-            </div>
-
-            <div class="{{ $id_etapa != 172 ? 'line' : 'line_off' }}"></div>
-
-            {{-- Etapa 2 --}}
-            <div style="width: 60px; transform: translateY(7px);" class="d-flex flex-column justify-content-center align-items-center">
-                <div class="etapa {{ in_array($id_etapa, [173]) ? 'active text-white' : (in_array($id_etapa, [66, 67, 72]) ? 'process' : '') }} border d-flex justify-content-center align-items-center">
-                    @if ($id_etapa == 173)
-                        <div class="success d-flex justify-content-center align-items-center">
-                            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-check2 bold text-white"
-                                 fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                <path fill-rule="evenodd"
-                                      d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
-                            </svg>
-                        </div>
-                    @endif
-                    <small class="font f-15 bold {{ in_array($id_etapa, [173, 178]) ? 'text-white' : 'text-muted' }}">2</small>
-                </div>
-                <small class="mt-1 mb-1 font c-carbon f-10 text-center">Datos del Solicitante</small>
-            </div>
-
-            <div class="{{ $id_etapa == 173 ? 'line' : 'line_off' }}"></div>
-
-            {{-- Etapa 3 --}}
-            <div style="width: 60px; transform: translateY(7px);" class="d-flex flex-column justify-content-center align-items-center">
-                <div class="etapa {{ $id_etapa == 173 ? 'active' : ($id_etapa == 178 ? 'process' : '') }} border d-flex justify-content-center align-items-center">
-                    @if ($id_etapa == 173)
-                        <div class="success d-flex justify-content-center align-items-center">
-                            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-check2 bold text-white"
-                                 fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                <path fill-rule="evenodd"
-                                      d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
-                            </svg>
-                        </div>
-                    @endif
-                    <small class="font f-15 bold {{ $id_etapa == 174 ? 'text-white' : 'text-muted' }}">3</small>
-                </div>
-                <small class="mt-1 mb-1 font c-carbon f-10 text-center">Datos Para Verificación</small>
-            </div>
-
-            <div class="{{ $id_etapa == 174 ? 'line' : 'line_off' }}"></div>
-
-            {{-- Etapa 4 --}}
-            <div style="width: 60px;" class="d-flex flex-column justify-content-center align-items-center">
-                <div class="etapa {{ $id_etapa == 175 ? 'active' : '' }} border d-flex justify-content-center align-items-center">
-                    @if ($id_etapa == 175)
-                        <div class="success d-flex justify-content-center align-items-center">
-                            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-check2 bold text-white"
-                                 fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                                <path fill-rule="evenodd"
-                                      d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
-                            </svg>
-                        </div>
-                    @endif
-                    <small class="font f-15 bold {{ $id_etapa == 175 ? 'text-white' : 'text-muted' }}">4</small>
-                </div>
-                <small class="mt-1 mb-1 font c-carbon f-10 text-center">Fotografías Adjuntas</small>
-            </div>
+                @if (! $loop->last)
+                    <div class="step-line"></div>
+                @endif
+            @endforeach
         </div>
     </div>
 </div>

--- a/resources/views/daiu/partials/inmueble_informacion.blade.php
+++ b/resources/views/daiu/partials/inmueble_informacion.blade.php
@@ -2,7 +2,10 @@
     <div class="col mt-4" id="top_4">
         <div class="card shadow-sm card_4 rounded border-none">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <small>Información del inmueble</small>
+                <div class="step-header">
+                    <span class="step-badge">4</span>
+                    <small class="step-title">Inmueble</small>
+                </div>
             </div>
             <div class="card-body" style="display: none;">
                 <form id="form_4">

--- a/resources/views/daiu/partials/selector_adecuaciones.blade.php
+++ b/resources/views/daiu/partials/selector_adecuaciones.blade.php
@@ -2,7 +2,10 @@
     <div class="col mt-4" id="top_3">
         <div class="card shadow-sm card_3 rounded border-none">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <small>Selector de Adecuaciones</small>
+                <div class="step-header">
+                    <span class="step-badge">3</span>
+                    <small class="step-title">Adecuaciones</small>
+                </div>
             </div>
             <div class="card-body" style="display: none;">
                 <form id="form_3">

--- a/resources/views/daiu/solicitud.blade.php
+++ b/resources/views/daiu/solicitud.blade.php
@@ -20,6 +20,8 @@
     @include('daiu.partials.selector_adecuaciones', ['id_solicitud' => $id_solicitud])
     @include('daiu.partials.inmueble_informacion', ['id_solicitud' => $id_solicitud])
     @include('daiu.partials.croquis_mapa', ['id_solicitud' => $id_solicitud])
+    @include('daiu.partials.anexos_memoria', ['id_solicitud' => $id_solicitud])
+    @include('daiu.partials.documentacion', ['id_solicitud' => $id_solicitud])
 
 @endsection
 
@@ -49,4 +51,6 @@
     <script src="{{ asset('js/daiu/inmueble_informacion.js') }}"></script>
     <script src="https://js.arcgis.com/4.25/"></script>
     <script src="{{ asset('js/daiu/croquis_mapa.js') }}"></script>
+    <script src="{{ asset('js/daiu/anexos_memoria.js') }}"></script>
+    <script src="{{ asset('js/daiu/documentacion.js') }}"></script>
 @endsection


### PR DESCRIPTION
## Summary
- show the seven-step workflow from Consulta through Documentación and label each solicitud card with its corresponding step badge
- center the croquis navigation buttons, rename the back action to "Regresar," and wire it to reopen the inmueble card
- add a Documentación card with placeholder file inputs, navigation hooks, and mock feedback while linking the step into the solicitud view

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4686f5a88832e97d495aac37e0003