### PR TITLE
Increase spacing below login title

### DIFF
--- a/resources/views/cuenta/login.blade.php
+++ b/resources/views/cuenta/login.blade.php
@@ -56,7 +56,7 @@
 
     <div class="contenedor border shadow-sm">
         <form id="form" action="{{url('cuenta/auth')}}" method="post" class="left">
-            <h2 class="font font-500" style="color: #090910;">Iniciar sesión</h4>
+            <h2 class="font font-500" style="color: #090910; margin-bottom: 50px;">Iniciar sesión</h4>
                 @csrf
 
                 <!-- Alert -->


### PR DESCRIPTION
## Summary
- add additional bottom margin to the login form title to create more spacing above the form fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7d6feb944832e96d04ff144f325f6